### PR TITLE
Handle when jshint has stopped processing because of too many errors

### DIFF
--- a/lib/hint.coffee
+++ b/lib/hint.coffee
@@ -43,8 +43,9 @@ hint = (coffeeSource, options, globals) ->
     console.log "jshint didn't pass but returned no errors"
     []
   else
-    jshint.errors = _.compact(jshint.errors)   # last jshint.errors item could be null if it bailed because too many errors 
     _.chain(jshint.errors)
+      # last jshint.errors item could be null if it bailed because too many errors 
+      .compact(jshint.errors)
       # Convert errors to use coffee source locations instead of js locations
       .map((error) ->
         [line, col] = sourceMap.sourceLocation [error.line - 1, error.character - 1]


### PR DESCRIPTION
I'm starting to use coffee-jshint on a project and found that jshint could fail because of too many errors in a file. (Usually this was due to globals I needed to tell jshint about).

With this change coffee-jshint will no longer error out in this condition.

Let me know if there's anything I need to do to clean this up further for inclusion.
