### PR TITLE
bump coffee-script version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
   },
   "license": "BSD",
   "dependencies": {
-    "coffee-script": "~1.6.3",
     "jshint": "~2.1.4",
     "optimist": "~0.6.0",
     "underscore": "~1.4.4"
+  },
+  "peerDependencies": {
+    "coffee-script": ">= 1.6 < 1.8"
   }
 }


### PR DESCRIPTION
I met a error from coffee-jshint caused by the following code:

```
setInterval check, 1000
.unref()
```

And found out the code using a new feature of CoffeeScript 1.7 so I need to bump the version of it in coffee-jshint.
