### PR TITLE
Accept a full .jshintrc configuration file

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -9,6 +9,9 @@ hintFiles = require("./lib-js/hint")
     'default-options-off':
       type: 'boolean'
       describe: 'turns off default options'
+    jshintrc:
+      alias: 'j'
+      describe: 'path to a file that holds JSHint configuration options'
     globals:
       alias: 'g'
       describe: 'comma separated list of global variable names to permit'
@@ -28,20 +31,13 @@ switch
   when argv.version then console.log require("./package.json").version
   when argv.help then console.log help()
   else
-    splitArgs = (strList) -> strList?.split(',') ? []
-
     # Filter out non-coffee paths
     {coffee, other} = _(argv._).groupBy (path) ->
       if /.+\.coffee$/.test path then "coffee" else "other"
     if argv.verbose and other?.length > 0
       console.log "Skipping files that don't end in .coffee:\n" + other.join('\n')
 
-    errors = hintFiles(coffee,
-      options: splitArgs argv.options
-      withDefaults: (not argv['default-options-off'])
-      globals: splitArgs argv.globals
-      verbose: argv.verbose
-    , true)
+    errors = hintFiles(coffee, argv, true)
     if _.flatten(errors).length is 0
       process.exit 0
     else

--- a/lib/hint.coffee
+++ b/lib/hint.coffee
@@ -22,17 +22,30 @@ errorsToSkip = [
 
 # If log is true, prints out results after processing each file
 hintFiles = (paths, config, log) ->
-  options = buildTrueObj(
-    if config.withDefaults
-    then _.union config.options, defaultOptions
-    else config.options)
+  if config.jshintrc
+    data = fs.readFileSync(config.jshintrc, {encoding: "utf8"})
+    jsonData = JSON.parse(removeComments(data))
+
+    if jsonData.globals
+      globals = jsonData.globals
+      delete jsonData.globals;
+
+    options = jsonData
+  else
+    globals = splitArgs config.globals
+    splittedOptions = splitArgs config.options
+    options = buildTrueObj(
+      if (not config['default-options-off'])
+      then _.union splittedOptions, defaultOptions
+      else splittedOptions)
+
   _.map paths, (path) ->
     try
       source = fs.readFileSync(path)
     catch err
       if config.verbose then console.log "Error reading #{path}"
       return []
-    errors = hint source, options, buildTrueObj config.globals
+    errors = hint source, options, buildTrueObj globals
     if log and errors.length > 0
       console.log "--------------------------------"
       console.log formatErrors path, errors
@@ -70,5 +83,12 @@ formatErrors = (path, errors) ->
 
 buildTrueObj = (keys) ->
   _.object keys, (true for i in [0..keys.length])
+
+removeComments = (str = "") ->
+  str = str.replace(/\/\*(?:(?!\*\/)[\s\S])*\*\//g, "");
+  str = str.replace(/\/\/[^\n\r]*/g, ""); # Everything after '//'
+  return str;
+
+splitArgs = (strList) -> strList?.split(',') ? []
 
 module.exports = hintFiles


### PR DESCRIPTION
I'd like to be able to provide a complete JSHint configuration file for the JSHint run. There are a few options that require an integer setting (such as 'maxcomplexity', 'maxlen', etc.).

The proposed solution does not heed the 'withDefaults' options. Would it be better to heed that setting with a jshintrc file as well?

I would add the necessary documentation for README as well in case you deem this pull request acceptable.
