### PR TITLE
Support CoffeeScript 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "underscore": "~1.4.4"
   },
   "peerDependencies": {
-    "coffee-script": ">= 1.6 <= 1.8"
+    "coffee-script": ">= 1.6 <= 1.8.0"
   },
   "devDependencies": {
     "coffee-script": "~1.6.0"


### PR DESCRIPTION
Changed package.json to properly support CoffeeScript 1.8.0 (lastest version)

CoffeeScript's changelog can be found [here](http://coffeescript.org/#changelog)
