### PR TITLE
add optional coffee-react-transform step

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -12,6 +12,10 @@ hintFiles = require("./lib-js/hint")
     globals:
       alias: 'g'
       describe: 'comma separated list of global variable names to permit'
+    react:
+      alias: 'r'
+      type: 'boolean'
+      describe: 'enable jsx transformation step'
     verbose:
       alias: 'v'
       type: 'boolean'
@@ -41,6 +45,7 @@ switch
       withDefaults: (not argv['default-options-off'])
       globals: splitArgs argv.globals
       verbose: argv.verbose
+      react: argv.react
     , true)
     if _.flatten(errors).length is 0
       process.exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coffee-jshint",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Checks CoffeeScript source for errors using JSHint",
   "engines": {
     "node": ">=0.8.x"
@@ -19,7 +19,8 @@
     "underscore": "~1.8.3"
   },
   "peerDependencies": {
-    "coffee-script": ">= 1.6 < 2"
+    "coffee-script": ">= 1.6 < 2",
+    "coffee-react-transform": ">= 0.1"
   },
   "devDependencies": {
     "coffee-script": "~1.6.0"


### PR DESCRIPTION
I want to be able to use coffee-jshint on projects that contain react JSX components. 

To handle this I've added an optional step which can be enabled via a command line flag to run coffee-react-transform over each file before passing that to the hint method.

Let me know if you see any problems with this or have some suggested changes.

Iain.
