### PR TITLE
remove 'console.log(options)'

### DIFF
--- a/lib/cli.coffee
+++ b/lib/cli.coffee
@@ -37,8 +37,6 @@ commander
 
 options     = commander.opts()
 
-console.log( options )
-
 splitArgs   = (strList) -> strList?.split(',') ? []
 
 


### PR DESCRIPTION
Currently the complete `options` map is printed each time the CLI is invoked and there is no way to avoid that.

In certain usage patterns -- e.g. a Makefile that lints each file independently so we only need to lint the files that have changed -- this creates a lot of noise.

This PR just removes that single `console.log` line.

I'm guessing this is essentially debugging code that was never removed.

But if this is intentional and you want to keep the console.log can we at least add some kind of flag that would enable/disable this output?

Personally I'd make the don't-print-the-options-map the default setting and use `--debug` or whatever to turn this on when wanted, but something like `--quiet` or `--dont-print-options` or  whatever would work fine too.

(If you really want I could create a PR for the flag-controlled version, it's pretty straightforward either way.)